### PR TITLE
Bump Mountainlab to 0.15.1

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -15,7 +15,7 @@ recipe.mountainsort \
 
 # avoid bootstrapping with existing published packages (i.e. don't include tjd2002/flatiron)
 # (but local always included--may need to blow away conda-bld if needed)
-channel_args="-c defaults -c conda-forge -c local -c flatiron --override-channels"
+channel_args="-c defaults -c conda-forge -c local --override-channels"
 append_args="--append-file=recipe_append.yaml"
 conda build --check $channel_args $append_args $RECIPE_DIRS_ORDERED || exit 2
 conda build --skip-existing $channel_args $append_args $RECIPE_DIRS_ORDERED || exit 3

--- a/recipe.mountainlab/meta.yaml
+++ b/recipe.mountainlab/meta.yaml
@@ -2,7 +2,7 @@
 {% set pkg_name = "mountainlab" %}
 {% set repo_name = "mountainlab-js" %}
 {% set repo_owner = "flatironinstitute" %}
-{% set version = "0.13.0" %}
+{% set version = "0.15.1" %}
 
 package:
   name: {{ pkg_name|lower }}
@@ -12,17 +12,12 @@ source:
    url: https://github.com/{{ repo_owner }}/{{ repo_name }}/archive/v{{ version }}.tar.gz
 
 build:
-  number: 0
+  number: 1
   script:
     - test -n "$BUILT_FROM_TOPDIR" # error if not built from mountainlab-conda directory
     - tgzfile=$(npm pack)
     - npm install -g $tgzfile
-
-    # install activate scripts
-    - mkdir -p "$PREFIX"/etc/conda/{de,}activate.d/
-    - cp "${RECIPE_DIR}"/mountainlab_activate.sh "$PREFIX"/etc/conda/activate.d/
-    - cp "${RECIPE_DIR}"/mountainlab_deactivate.sh "$PREFIX"/etc/conda/deactivate.d/
-
+    
     # set up mountainlab directories
     - mkdir -p "$PREFIX"/etc/mountainlab/{packages,database}
     - touch "$PREFIX"/etc/mountainlab/{packages,database}/.conda_keep # conda ignores empty directories
@@ -39,6 +34,10 @@ test:
     - npm list -g mountainlab
     - ml-config
     - ml-list-processors
+    - ml-spec hello.world
+    - ml-spec hello.world -p
+    - ml-run-process --help
+    - ml-prv-locate --help
   requires:
     - nodejs
 


### PR DESCRIPTION
I had been building from my fork of mountainlab-conda, soon I'll start using the flatiron repo instead; moving some changes over here.